### PR TITLE
Make "Next" and "Previous work properly

### DIFF
--- a/_includes/navigate-collection.html
+++ b/_includes/navigate-collection.html
@@ -9,6 +9,10 @@ DO NOT REMOVE WITHOUT READING ABOVE NOTE
 	{% assign  document = site[the_collection] %}
 {% endif %}
 
+{% if page.collection == 'posts' %}
+	{% assign  document = site[the_collection] | reverse %}
+{% endif %}
+
 {% for links in document %}
   {% if links.title == page.title %}
     {% unless forloop.first %}
@@ -24,27 +28,16 @@ DO NOT REMOVE WITHOUT READING ABOVE NOTE
 
 DO NOT REMOVE WITHOUT READING ABOVE NOTE
 -->
-
 <p class="float-right">
-	
-    <a class="btn btn-primary {% unless nexturl %} disabled {% endunless %}"
-        {% if nexturl %}
-            href="{{ site.baseurl }}{{ nexturl }}"
-        {% else %}
-            aria-disabled="true"
-        {% endif %}
-    >
-        &laquo; Next
+
+    <a class="btn btn-primary {% unless prevurl %} disabled {% endunless %}" {% if prevurl %} href="{{ site.baseurl }}{{ prevurl }}"
+        {% else %} aria-disabled="true" {% endif %}>
+        &laquo; Previous
     </a>
-	
-    <a class="btn btn-primary {% unless prevurl %} disabled {% endunless %}"
-        {% if prevurl %}
-            href="{{ site.baseurl }}{{ prevurl }}"
-        {% else %}
-            aria-disabled="true"
-        {% endif %}
-    >
-        Previous &raquo;
+
+    <a class="btn btn-primary {% unless nexturl %} disabled {% endunless %}" {% if nexturl %} href="{{ site.baseurl }}{{ nexturl }}"
+        {% else %} aria-disabled="true" {% endif %}>
+        Next &raquo;
     </a>
 
 </p>


### PR DESCRIPTION
Posts and Minutes are ordered differently in `page.collection` - honestly I've no clue why. Minutes is ordered correctly, so this checks whether the collection is posts, and if so reverses it. Also switched the button order so Next is on the right.